### PR TITLE
qualify imports from stdlib, in particular `random`

### DIFF
--- a/src/cdt/dt.nim
+++ b/src/cdt/dt.nim
@@ -7,12 +7,12 @@
 #
 # https://static.aminer.org/pdf/PDF/000/111/347/fast_randomized_point_location_without_preprocessing_in_two_and_three.pdf
 #
-# (C) 2019 S. Salewski 
+# (C) 2019 S. Salewski
 # v0.1 26-MAY-2019
 
 import geometry
 import types, vectors, vertices, edges, subdivisions, salewski, minmax
-import tables, random
+import std / [tables, random]
 from math import sqrt, pow
 from salewski import `^`
 

--- a/src/cdt/subdivisions.nim
+++ b/src/cdt/subdivisions.nim
@@ -1,5 +1,5 @@
 # http://www.karlchenofhell.org/cppswp/lischinski.pdf
-import random, tables
+import std / [random, tables]
 import types, vectors, vertices, edges
 
 type
@@ -50,7 +50,7 @@ proc removeVertex*(s: var Subdivision; v: Vertex) =
       if edge == start:
         break
   assert s.vertices[v.id.int] == v
-  let delPos = v.seqPos 
+  let delPos = v.seqPos
   let id = s.vertIDs[^1].int
   let v1 = s.vertices[id]
   assert v1 != nil


### PR DESCRIPTION
It clashes with
https://github.com/oprypin/nim-random
and a modern Nim compiler might not automatically prefer the stdlib anymore!

This just confused me for more than half an hour, because using a lockfile I couldn't compile and without I could. I don't quite get it (that `random` module was available in both cases). But well, this fixes it.